### PR TITLE
support typing_extensions 4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ exclude = ["tests/", "examples/"]
 [tool.poetry.dependencies]
 python = "^3.7"
 dataclasses-json = "^0.3.2"
-typing-extensions = "^3.7"
+typing-extensions = ">=3.7,<5"
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.1.1"


### PR DESCRIPTION
It appears that typing_extensions 4 works just fine for pykeybasebot. We need this in our virtualenv in order to avoid dependency conflicts with other packages, e.g. pydantic 2.2.1 (which requires typing_extensions ^4)